### PR TITLE
:sparkles: feat: Add GitHub Actions workflow to trigger Jenkins jobs on push

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -1,0 +1,31 @@
+name: Trigger Jenkins Job
+
+on:
+  push:
+    branches:
+      - dev
+      - staging
+      - main
+  workflow_dispatch: # Allows manual execution
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Get the branch and build Jenkins URL
+      - name: Get branch name and build Jenkins URL
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          JENKINS_URL="https://automation.prms.cgiar.org/job/innovation-catalog-${BRANCH_NAME}/build"
+          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+
+      # Step 2: Run curl to trigger the job
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate triggering Jenkins jobs for the project's main branches. The workflow supports both automatic execution on branch pushes and manual execution, and securely passes credentials for authentication.

Automation and CI/CD integration:

* Added a new workflow file `.github/workflows/jenkins-trigger.yml` that triggers Jenkins jobs for the `dev`, `staging`, and `main` branches when code is pushed or the workflow is manually dispatched.
* Configured steps to dynamically build the Jenkins job URL based on the branch name and securely pass Jenkins credentials using GitHub secrets.
* Implemented a step to trigger the appropriate Jenkins job using a POST request via `curl`.