### PR TITLE
🔧chore: update cron schedule to trigger Jenkins job at 6 AM only

### DIFF
--- a/.github/workflows/jenkins-trigger-schedule.yml
+++ b/.github/workflows/jenkins-trigger-schedule.yml
@@ -2,7 +2,7 @@ name: Trigger Jenkins Job
 
 on:
   schedule:
-    - cron: "0 6,14,22 * * *"
+    - cron: "0 6 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request makes a small update to the scheduled trigger for the Jenkins job workflow. The job will now run once daily at 6:00 AM instead of three times per day.